### PR TITLE
Fix OSM export with NULL geometry problem

### DIFF
--- a/src/osm/src/main/java/org/geogig/osm/internal/MappingRule.java
+++ b/src/osm/src/main/java/org/geogig/osm/internal/MappingRule.java
@@ -327,6 +327,9 @@ public class MappingRule {
         GeomRestriction restriction = getGeomRestriction();
         GeometryAttribute property = feature.getDefaultGeometryProperty();
         Geometry geom = (Geometry) property.getValue();
+        if (geom == null) {
+        	return false; // not compatible if it doesn't exist
+        }
         if (geom.getClass().equals(Point.class)) {
             return geometryType == Point.class;
         } else {


### PR DESCRIPTION
When exporting OSM data, there are often NULL geometries.  This
causes issues (NPE) in the export when processing the mapping rules.
This will filter out null geometries.

Signed-off-by: DBlasby <dblasby@boundlessgeo.com>